### PR TITLE
Remove deprecated attribute

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,7 +54,6 @@ class sysfs (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    force   => true,
     require => Package['sysfsutils'],
   }
 


### PR DESCRIPTION
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Concat[/etc/sysfs.conf]: has no parameter named 'force' at /var/lib/puppet-gitlab/production/modules/sysfs/manifests/init.pp:53
```