### PR TITLE
manifests: install service on RHEL8.x as well

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ class sysfs (
     ensure => installed
   }
 
-  if ($::osfamily == 'RedHat') and ($::operatingsystemmajrelease == '7')  {
+  if ($::osfamily == 'RedHat') and (versioncmp($::facts['os']['release']['full'], '7') >= 0) {
     file { '/usr/local/bin/sysfs-reload' :
       source => 'puppet:///modules/sysfs/sysfs-reload',
       owner  => root,


### PR DESCRIPTION
Modify the `if` clause so that it would match RHEL8 as well.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>