### PR TITLE
Remove deprecated is_hash

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@
 # Copyright 2015 Dan Foster, unless otherwise noted.
 #
 class sysfs (
-  $settings  = undef
+  Optional[Hash] $settings = undef
 ) {
   package { 'sysfsutils':
     ensure => installed
@@ -58,7 +58,7 @@ class sysfs (
     require => Package['sysfsutils'],
   }
 
-  if is_hash($settings) {
+  if $settings {
     create_resources('sysfs::setting', $settings)
   }
 


### PR DESCRIPTION
`is_hash` has been deprecated as it is now covered by native Puppet data types and thus was removed from the latest `stdlib` [9.0.0](https://forge.puppet.com/modules/puppetlabs/stdlib/9.0.0/changelog#changed) causing a `Evaluation Error: Unknown function: 'is_hash'` error.