### PR TITLE
change default mode, allow to overwrite this change

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,9 @@
 # Copyright 2015 Dan Foster, unless otherwise noted.
 #
 class sysfs (
-  Optional[Hash] $settings = undef
+  Optional[Hash] $settings  = undef,
+  String $exec_mode         = '0700',
+  String $service_mode      = '0444',
 ) {
   package { 'sysfsutils':
     ensure => installed
@@ -27,14 +29,14 @@ class sysfs (
       source => 'puppet:///modules/sysfs/sysfs-reload',
       owner  => root,
       group  => root,
-      mode   => '0700',
+      mode   => $exec_mode,
       before => File['/etc/systemd/system/sysfsutils.service']
     }
     file { '/etc/systemd/system/sysfsutils.service' :
       source => 'puppet:///modules/sysfs/sysfsutils.service',
       owner  => root,
       group  => root,
-      mode   => '0700',
+      mode   => $service_mode,
       before => Service['sysfsutils'],
     }
     exec { 'sysfsutils_reload_rhel':


### PR DESCRIPTION
Dear maintainer,

This pull  request allows to change permissions (in `chmod` way only) of the systemd and executable created files on Redhat.

This also change the default mode of systemd file to remove warning messages in the logs:
```
May  6 18:36:00 foo systemd[1]: Configuration file /etc/systemd/system/sysfsutils.service is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
May  6 18:37:00 foo systemd[1]: Configuration file /etc/systemd/system/sysfsutils.service is marked executable. Please remove executable permission bits. Proceeding anyway.
```

Regards